### PR TITLE
fixed the std::invalid_argument error

### DIFF
--- a/SCA/core/src/TemplateTable.h
+++ b/SCA/core/src/TemplateTable.h
@@ -40,6 +40,8 @@ public:
 
 		while (getline(template_file, line))
 		{
+			// skip the first line (first line contains the version number)
+			getline(template_file, line);
 			//seperating lines from file
 			string key = line.substr(0, line.find(","));
 			line.erase(0, line.find(",") + 1);


### PR DESCRIPTION
- Problem was with the first line in the rules.txt file (Ver 1.1)
- skipped first line and ran successfully, output files were created