### PR TITLE
Bug Fixes and Changes

### DIFF
--- a/SCA/core/src/Component.h
+++ b/SCA/core/src/Component.h
@@ -2,6 +2,7 @@
 #define COMPONENT
 
 #include "SCA.h"
+#include "Tree.h"
 
 using namespace std;
 
@@ -61,7 +62,11 @@ public:
 	int getStartLineCount();
 
 	//searches from start node to find data, returns first node with the same data in it.
-	Node* find(string data, Node* start);
+	Node* findNode(string data, Node* start);
+
+	// accessor Methods
+	Node* getTreeRootNode();
+	Node* getComponentRootNode();
 };
 
 Component::Component() {
@@ -77,6 +82,14 @@ Component::Component(Node* compRtPtr) {
 Component::Component(Node* compRtPtr, Node* treeRtPtr) {
 	componentRootNode = compRtPtr;
 	treeRootNode = treeRtPtr;
+}
+
+Node* Component::getTreeRootNode() {
+	return treeRootNode;
+}
+
+Node* Component::getComponentRootNode() {
+	return componentRootNode;
 }
 
 void Component::setStatementType(int type){
@@ -143,7 +156,7 @@ int Component::getStartLineCount() {
 	return startLineCount;
 }
 
-Node* Component::find(string data, Node* start)
+Node* Component::findNode(string data, Node* start)
 {
 	Node* nodeIter = start;
 
@@ -158,7 +171,7 @@ Node* Component::find(string data, Node* start)
 	int totalChildren = nodeIter->getChildCount();
 
 	for (int i = 0; i < totalChildren; i++) {
-		find(data, nodeIter->getChild(i));
+		findNode(data, nodeIter->getChild(i));
 	}
 }
 

--- a/SCA/core/src/Driver.cpp
+++ b/SCA/core/src/Driver.cpp
@@ -83,7 +83,7 @@ void explore(char *dir_name) {
 				matchedSuggestions = sca->matchTemplateWithTree();
 				cout << "Matched suggestions with tree\n";
 
-				htmlFilePath = sca->createHTMLFile();
+				htmlFilePath = sca->createHTMLFile(matchedSuggestions);
 				cout << "Created html file\n";
 			}
 			else {

--- a/SCA/core/src/ForLoop.h
+++ b/SCA/core/src/ForLoop.h
@@ -43,22 +43,22 @@ void ForLoop::setVariables(Tree* rt)
 	Node* walker2;
 
 	//find first line number
-	walker = find("for", statementStart);
+	walker = findNode("for", statementStart);
 	addAnStartLine(walker->getLineNum());
 
 	//set last line number
 	addAnEndLine(statementStart);
 
 	//Find out what the iterator is called
-	walker = find("forInitStatement", statementStart);
-	walker2 = find("unqualifiedId", walker);
+	walker = findNode("forInitStatement", statementStart);
+	walker2 = findNode("unqualifiedId", walker);
 	if (walker2 == nullptr)//unqualifiedId not found
 		iteratorInt = "Not an unqualifiedId";
 	else
 		iteratorInt = walker2->getChild(0)->getData();
 
 	//find the condition
-	walker = find("condition", statementStart);
+	walker = findNode("condition", statementStart);
 	if (walker == nullptr)
 		condition = "No condition was found";
 	else
@@ -120,7 +120,7 @@ void ForLoop::setVariables(Tree* rt)
 	}
 	
 	//find expression
-	walker = find("expression", statementStart);
+	walker = findNode("expression", statementStart);
 	while (walker->getChildCount() == 1)
 		walker = walker->getChild(0);
 

--- a/SCA/core/src/If.h
+++ b/SCA/core/src/If.h
@@ -119,7 +119,7 @@ void If::setVariables(Tree* rt)
 
 
 		statementStart = statementStart->getChild(6);
-		if (statementStart->getChild(0)->getData == "selectionStatement")	//means there's another if
+		if (statementStart->getChild(0)->getData() == "selectionStatement")	//means there's another if
 		{
 			statementStart = statementStart->getChild(0);
 
@@ -200,6 +200,7 @@ void If::setVariables(Tree* rt)
 Node* If::find(string data, Node* start)
 {
 	Node* nodeIter = start;
+	string iteratorInt;
 
 	if (nodeIter->getData() == data)
 	{

--- a/SCA/core/src/SCA.cpp
+++ b/SCA/core/src/SCA.cpp
@@ -396,17 +396,19 @@ string SCA::matchTemplateWithTree() const {
 	templateMatcher->setRulesArraySize();
 	templateMatcher->checkTreeForErrors(ast->getRoot());
 
+	cout << "Inside mathTemplateWithTree() BEFORE retreiveComponents()" << endl;
 	// Use tree to gather Components
 	templateMatcher->retreiveComponents(ast);
+	cout << "Inside mathTemplateWithTree() AFTER retreiveComponents()" << endl;
 
 	return templateMatcher->outputSuggestions();
 }
 
 // Undefined Function
-string SCA::createHTMLFile() {
+string SCA::createHTMLFile(string& matchedSugg) {
 	createHTML* create_html = new createHTML();
 	create_html->setCPPfile(cppFilePath);
-	create_html->setSuggestions(matchTemplateWithTree());
+	create_html->setSuggestions(matchedSugg);
 
 	// changes to filename and file path to match directory structure
 	int pos = cppFilePath.find_last_of("/");
@@ -415,7 +417,6 @@ string SCA::createHTMLFile() {
 	filename = filename.substr(0, pos);
 	string htmlLocation = htmlDir + "/" + filename + ".html";
 	create_html->setHTMLlocation(htmlLocation);
-	create_html->makeCSSfile();
 	create_html->makeHTMLfile();
 	return htmlLocation;
 }

--- a/SCA/core/src/SCA.h
+++ b/SCA/core/src/SCA.h
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <vector>
 #include "ANTLR_Server.h"
+#include "Component.h"
 #include "AST_Parser.h"
 #include "TemplateTable.h"
 #include "Template_Matcher.h"
@@ -39,7 +40,7 @@ public:
 	Node* readANTLROutputTree(string& treeTxtFilePath);
 	bool readANTLROutputErrors(string& errorTxtFilePath);
 	string matchTemplateWithTree() const;
-	string createHTMLFile();
+	string createHTMLFile(string& matchedSuggestions);
 };
 
 #include "SCA.cpp"

--- a/SCA/core/src/SCAInterface.h
+++ b/SCA/core/src/SCAInterface.h
@@ -63,7 +63,7 @@ virtual std::string matchTemplateWithTree() const = 0;
     @post  An HTML file is created and stored in the same folder.
     @param None.
     @return  Path to newly created HTML file */
-virtual string createHTMLFile() = 0;
+virtual string createHTMLFile(string& matchedSuggestions) = 0;
 };
 
 #endif

--- a/SCA/core/src/TemplateTable.h
+++ b/SCA/core/src/TemplateTable.h
@@ -3,6 +3,7 @@
 
 #include "SCA.h"
 #include "Rule.h"
+#include "Component.h"
 #include <iostream>
 #include <fstream>
 #include <string>

--- a/SCA/core/src/Template_Matcher.h
+++ b/SCA/core/src/Template_Matcher.h
@@ -2,6 +2,7 @@
 #define TEMPLATE_MATCHER
 
 #include "SCA.h"
+#include "While_Loop.h"
 #include <string>
 
 using namespace std;
@@ -178,12 +179,14 @@ string Template_Matcher::outputSuggestions()
 void Template_Matcher::_fillIterationNodeVector(Tree* tree) {
 	tree->filltokenNodeVector(iterationStmt, tree->getRoot());
 	iterationNodes = tree->getTokenNodes();
+	tree->clearTokenNodes();
 }
 
 	
 void Template_Matcher::_fillSelectionNodeVector(Tree* tree) {
 	tree->filltokenNodeVector(selectionStmt, tree->getRoot());
 	selectionNodes = tree->getTokenNodes();
+	tree->clearTokenNodes();
 }
 
 void Template_Matcher::retreiveComponents(Tree* tree) {
@@ -191,6 +194,7 @@ void Template_Matcher::retreiveComponents(Tree* tree) {
 	_fillIterationNodeVector(tree);
 	_fillSelectionNodeVector(tree);
 	Node* temp;
+	string testToken = "";
 
 	// iterate though each node that contains an iterationStatement
 	for (int i = 0; i < iterationNodes.size(); i++) {
@@ -198,46 +202,49 @@ void Template_Matcher::retreiveComponents(Tree* tree) {
 		while (temp->getChildCount() != 0) {
 			temp = temp->getChild(0);
 		}
-		switch(temp->getData()) {
-			case "for":
-				// hand control to for_component, pass in rootNode of Tree and iterationNode[i]
-				break;
-			case "while":
-				While_Loop* aWhileLoop = new While_Loop(iterationNodes[i], tree->getRoot(), "while");
-				aWhileLoop->extractAllInfo();
-				whileLoopComponents.push_back(aWhileLoop);
-				break;
-			case "do":
-				While_Loop* aDoWhileLoop = new While_Loop(iterationNodes[i], tree->getRoot(), "do");
-				aDoWhileLoop->extractAllInfo();
-				whileLoopComponents.push_back(aDoWhileLoop);
-				break;
-			default:
-				break;
+		testToken = temp->getData();
+		
+		if (testToken == "for") {
+			// hand control to for_component, pass in rootNode of Tree and iterationNode[i]
+			break;
+		}
+		else if (testToken == "while") {
+			While_Loop* aWhileLoop = new While_Loop(iterationNodes[i], tree->getRoot(), "while");
+			aWhileLoop->extractAllInfo();
+			whileLoopComponents.push_back(aWhileLoop);
+			break;
+		}
+		else if (testToken == "do") {
+			While_Loop* aDoWhileLoop = new While_Loop(iterationNodes[i], tree->getRoot(), "do");
+			aDoWhileLoop->extractAllInfo();
+			whileLoopComponents.push_back(aDoWhileLoop);
+			break;
 		}
 	}
 
 	// iterate through each node that contains a selectionStatement
 	for (int i = 0; i < selectionNodes.size(); i++) {
-		temp = iterationNodes(i);
+		temp = iterationNodes[i];
 		while (temp->getChildCount() != 0) {
 			temp = temp->getChild(0);
 		}
-		switch(temp->getData()) {
-			case "if":
-				// hand control to if_component, pass in rootNode of Tree and iterationNode[i]
-				break;
-			case "switch":
-				// hand control to switch_component, pass in rootNode of Tree and iterationNode[i]
-				break;
-			default:
-				break;
+
+		testToken = temp->getData();
+		if (testToken == "if") {
+			// hand control to if_component, pass in rootNode of Tree and iterationNode[i]
+			break;
+		}
+		else if (testToken == "switch") {
+			// hand control to switch_component, pass in rootNode of Tree and iterationNode[i]
+			break;
 		}
 	}
+	cout << "Looped through selection statements\n";
 
 	for (int i = 0; i < whileLoopComponents.size(); i++) {
 		whileLoopComponents[i]->printLoopInfo();
 	}
+	cout << "End of retreive components function\n";
 }
 
 

--- a/SCA/core/src/While_Loop.h
+++ b/SCA/core/src/While_Loop.h
@@ -2,6 +2,7 @@
 #define WHILE_COMPONENT_
 
 #include "Component.h"
+#include <algorithm>
 
 class While_Loop : public Component 
 {
@@ -19,7 +20,7 @@ private:
     Node* stmtRtNode;
 public:
     While_Loop();
-    While_Loop(string lType);
+    While_Loop(Node* compRtPtr, Node* treeRtPtr, string lType);
 
     // uses member functions to extract all information from the tree
     void extractAllInfo();
@@ -61,14 +62,14 @@ While_Loop::While_Loop(Node* compRtNode, Node* treeRtNode, string lType) : Compo
 }
 
 void While_Loop::extractBegLineNum() {
-    if (componentRootNode->getChildCount() > 0) {
-        begLineNum = componentRootNode->getChild(0)->getLineNum();
+    if (getComponentRootNode()->getChildCount() > 0) {
+        begLineNum = getComponentRootNode()->getChild(0)->getLineNum();
     }
 }
 
 void While_Loop::extractTestExpression() {
-    Node* walker = componentRootNode;
-    for (int i = 0; i < componentRootNode->getChildCount(); i++) {
+    Node* walker = getComponentRootNode();
+    for (int i = 0; i < getComponentRootNode()->getChildCount(); i++) {
         if (loopType == "while" && walker->getChild(i)->getData() == "condition") {
             conditionRtNode = walker->getChild(i);
             break;
@@ -102,8 +103,8 @@ void While_Loop::_extractTestExpression(Node* condRtNode) {
 }
 
 void While_Loop::extractBody() {
-    Node* walker = componentRootNode;
-    for (int i = 0; i < componentRootNode->getChildCount(); i++) {
+    Node* walker = getComponentRootNode();
+    for (int i = 0; i < getComponentRootNode()->getChildCount(); i++) {
         if (walker->getChild(i)->getData() == "statement") {
             stmtRtNode = walker->getChild(i);
             break;
@@ -134,7 +135,7 @@ void While_Loop::_extractBody(Node* stRtNode) {
 
 void While_Loop::extractIncrement() {
     for (int i = 0; i < testExpression.size(); i++) {
-        if (testExpression[i]->getParent() == "unqualifiedId") {
+        if (testExpression[i]->getParent()->getData() == "unqualifiedId") {
             testVariable.push_back(testExpression[i]->getData());
         }
     }
@@ -157,7 +158,7 @@ void While_Loop::extractIncrement() {
 
 void While_Loop::extractSetupVariable() {
     // extract all leaf nodes up the point where the loop begins
-    _extractSetupVariable(treeRootNode);
+    _extractSetupVariable(getTreeRootNode());
     Node* markBegOfStatement = new Node("StatementBegin");
 
     // run through the nodes of source code prior to the beginning of the loop to find the setup variable
@@ -181,7 +182,7 @@ void While_Loop::extractSetupVariable() {
     }
 
     // extract last statment prior to the start of the for loop using the test variable
-    for (int i = setupVariableInstances.size(); i >= 0; i--) {
+    for (int i = setupVariableInstances.size() - 1; i >= 0; i--) {
         if (setupVariableInstances[i]->getData() == "StatementBegin") {
             break;
         }
@@ -245,8 +246,8 @@ void While_Loop::printLoopInfo() {
     }
 
     cout << endl << "Test Variable(s): ";
-    for (int i = 0; i < testVariables.size(); i++) {
-        cout << testVariables[i] << " ";
+    for (int i = 0; i < testVariable.size(); i++) {
+        cout << testVariable[i] << " ";
     }
 
     cout << endl << "Increment Statement(s): ";
@@ -261,7 +262,7 @@ void While_Loop::printLoopInfo() {
         }
     }
 
-    cout << loopType << " (";
+    cout << endl << loopType << " (";
     for (int i = 0; i < testExpression.size(); i++) {
         cout << testExpression[i]->getData() << " ";
     }


### PR DESCRIPTION
- Added parameter to createHTMLFile(), execution of createHTMLFile was causing the matchTemplateWithTree() function to run twice so to fix it we will pass in the suggestions produced by matchTemplateWithTree()
- Fixed bugs in my component class (While_Loop), runs and extracts while loop properly.. Right now it just prints the component to the console. Later I will add the ToString() function so it can be written in the HTML output
- Changed the function 'find()' in Component.h to 'findNode()' and changed all references to it in 'ForLoop.h'.
- Added accessor methods for componentRootNode and TreeRootNode in 'Component.h'
- Code compiles and runs successfully on my VM