### PR TITLE
Fixed segmentation fault error

### DIFF
--- a/SCA/core/src/SCA.cpp
+++ b/SCA/core/src/SCA.cpp
@@ -9,6 +9,8 @@ SCA::SCA(const string& pathToCppFile) {
 	ast = nullptr;
 	templateTableFile = "";
 	htmlDir = "";
+	iterationNodes.clear();
+	selectionNodes.clear();
 }
 
 SCA::SCA(const string& pathToCppFile, const string& pathToTemplateTable) {
@@ -16,6 +18,8 @@ SCA::SCA(const string& pathToCppFile, const string& pathToTemplateTable) {
 	ast = nullptr;
 	templateTableFile = pathToTemplateTable;
 	htmlDir = "";
+	iterationNodes.clear();
+	selectionNodes.clear();
 }
 
 SCA::SCA(const string& pathToCppFile, const string& pathToTemplateTable, const string& pathToHtmlDir) {
@@ -23,6 +27,8 @@ SCA::SCA(const string& pathToCppFile, const string& pathToTemplateTable, const s
 	ast = nullptr;
 	templateTableFile = pathToTemplateTable;
 	htmlDir = pathToHtmlDir;
+	iterationNodes.clear();
+	selectionNodes.clear();
 }
 
 bool SCA::existsFile(string filePath) const {
@@ -373,6 +379,12 @@ Node* SCA::readANTLROutputTree(string& treeTxtFilePath) {
 		ast_parser->getNodeLineNums();
 
 		ast = ast_parser->getTree();
+		ast->filltokenNodeVector("iterationStatement", ast->getRoot());
+		iterationNodes = ast->getTokenNodes();
+		ast->clearTokenNodes();
+		ast->filltokenNodeVector("selectionStatement", ast->getRoot());
+		selectionNodes = ast->getTokenNodes();
+		ast->clearTokenNodes();
 	}
 	else {
 		cout << "File " << treeTxtFilePath << " does not exist..." << endl;
@@ -397,7 +409,7 @@ string SCA::matchTemplateWithTree() const {
 	templateMatcher->checkTreeForErrors(ast->getRoot());
 
 	// Use tree to gather Components
-	templateMatcher->retreiveComponents(ast);
+	templateMatcher->retreiveComponents(ast, iterationNodes, selectionNodes);
 
 	return templateMatcher->outputSuggestions();
 }

--- a/SCA/core/src/SCA.h
+++ b/SCA/core/src/SCA.h
@@ -27,6 +27,8 @@ private:
 	string templateTableFile;
 	string htmlDir;
 	Tree* ast;
+	vector<Node*> iterationNodes;
+	vector<Node*> selectionNodes;
 
 public:
 	SCA();

--- a/SCA/core/src/Template_Matcher.h
+++ b/SCA/core/src/Template_Matcher.h
@@ -19,8 +19,6 @@ private:
 	int* rulesViolatedLines;
 	string suggestions;
 	string componentString;
-	vector<Node*> iterationNodes;
-	vector<Node*> selectionNodes;
 	vector<While_Loop*> whileLoopComponents;
 
 public:
@@ -51,14 +49,8 @@ public:
 	//returns template table size, the number of rules.
 	int getTemplateTableSize();
 
-	// fills the iteration node vector with all node instances of iteration statements in source code
-	void _fillIterationNodeVector(Tree* tree);
-
-	// fills the selection node vector with all node instances of selection statements in source code
-	void _fillSelectionNodeVector(Tree* tree);
-
 	// Calls the fill node vector functions then iterates through each vector handing node to corresponding component class to build component
-	void retreiveComponents(Tree* tree);
+	void retreiveComponents(Tree* tree, vector<Node*> iterNodes, vector<Node*> selectNodes);
 
 };
 
@@ -178,29 +170,14 @@ string Template_Matcher::outputSuggestions()
 	return suggestions;
 }
 
-void Template_Matcher::_fillIterationNodeVector(Tree* tree) {
-	tree->filltokenNodeVector(iterationStmt, tree->getRoot());
-	iterationNodes = tree->getTokenNodes();
-	tree->clearTokenNodes();
-}
+void Template_Matcher::retreiveComponents(Tree* tree, vector<Node*> iterNodes, vector<Node*> selectNodes) {
 
-	
-void Template_Matcher::_fillSelectionNodeVector(Tree* tree) {
-	tree->filltokenNodeVector(selectionStmt, tree->getRoot());
-	selectionNodes = tree->getTokenNodes();
-	tree->clearTokenNodes();
-}
-
-void Template_Matcher::retreiveComponents(Tree* tree) {
-	// populate vectors with nodes from tree
-	_fillIterationNodeVector(tree);
-	_fillSelectionNodeVector(tree);
 	Node* temp;
 	string testToken = "";
 
 	// iterate though each node that contains an iterationStatement
-	for (int i = 0; i < iterationNodes.size(); i++) {
-		temp = iterationNodes[i];
+	for (int i = 0; i < iterNodes.size(); i++) {
+		temp = iterNodes[i];
 		while (temp->getChildCount() != 0) {
 			temp = temp->getChild(0);
 		}
@@ -211,13 +188,13 @@ void Template_Matcher::retreiveComponents(Tree* tree) {
 			break;
 		}
 		else if (testToken == "while") {
-			While_Loop* aWhileLoop = new While_Loop(iterationNodes[i], tree->getRoot(), "while");
+			While_Loop* aWhileLoop = new While_Loop(iterNodes[i], tree->getRoot(), "while");
 			aWhileLoop->extractAllInfo();
 			whileLoopComponents.push_back(aWhileLoop);
 			break;
 		}
 		else if (testToken == "do") {
-			While_Loop* aDoWhileLoop = new While_Loop(iterationNodes[i], tree->getRoot(), "do");
+			While_Loop* aDoWhileLoop = new While_Loop(iterNodes[i], tree->getRoot(), "do");
 			aDoWhileLoop->extractAllInfo();
 			whileLoopComponents.push_back(aDoWhileLoop);
 			break;
@@ -225,8 +202,8 @@ void Template_Matcher::retreiveComponents(Tree* tree) {
 	}
 
 	// iterate through each node that contains a selectionStatement
-	for (int i = 0; i < selectionNodes.size(); i++) {
-		temp = iterationNodes[i];
+	for (int i = 0; i < selectNodes.size(); i++) {
+		temp = selectNodes[i];
 		while (temp->getChildCount() != 0) {
 			temp = temp->getChild(0);
 		}

--- a/SCA/core/src/Tree.cpp
+++ b/SCA/core/src/Tree.cpp
@@ -170,18 +170,17 @@ string Tree::trim(const string& line) {
 }
 
 void Tree::filltokenNodeVector(const string& token, Node* rt) {
-	Node* nodeIter = rt;
-	if (nodeIter->getChildCount() == 0) {
+	if (rt->getChildCount() == 0) {
 		return;
 	}
 
-	int totalChildren = nodeIter->getChildCount();
+	int totalChildren = rt->getChildCount();
 	
 	for (int i = 0; i < totalChildren; i++) {
-		if (nodeIter->getChild(i)->getData() == token) {
-			tokenNodes.push_back(nodeIter->getChild(i));
+		if (rt->getChild(i)->getData() == token) {
+			tokenNodes.push_back(rt->getChild(i));
 		}
-		filltokenNodeVector(token, nodeIter->getChild(i));
+		filltokenNodeVector(token, rt->getChild(i));
 	}
 }
 

--- a/SCA/user/source-code/Assignment_6_Bonus.cpp
+++ b/SCA/user/source-code/Assignment_6_Bonus.cpp
@@ -24,7 +24,7 @@ int main()
 	double weightedSum = 0.0;
 	int index = 0;
 
-	inData.open("C:\\Users\\itsto\\Google Drive\\College\\J-term '20\\CSIT 121\\grade.txt");
+	inData.open("grade.txt");
 	
 	char letterGrade[20][2];
 	char firstName[20][12];


### PR DESCRIPTION
- Moved the iterationNode and selectionNode vectors to the SCA class.
- iteration node and selection node vectors are now filled immediately after the creation of the tree in memory, this fixes the segmentation fault error
- removed path reference in Assignment 6
- Changed Template_Matcher and SCA.cpp to work with the new way of filling the node vectors